### PR TITLE
fix and test operators

### DIFF
--- a/src/JsonDSL/DSL.fs
+++ b/src/JsonDSL/DSL.fs
@@ -56,6 +56,13 @@ module DSL =
         | :? Result<byte,exn> as r -> parseResult f r
         | :? Result<System.DateTime,exn> as r -> parseResult f r
 
+        | :? string as s ->             JEntity.ofGeneric s
+        | :? int as i ->                JEntity.ofGeneric i
+        | :? float as f ->              JEntity.ofGeneric f
+        | :? single as s ->             JEntity.ofGeneric s
+        | :? byte as b ->               JEntity.ofGeneric b
+        | :? System.DateTime as d ->    JEntity.ofGeneric d
+
         | v -> failwith $"Could not parse value {v}. Only string,int,float,single,byte,System.DateTime allowed."
 
     /// Required value operator

--- a/src/JsonDSL/JEntity.fs
+++ b/src/JsonDSL/JEntity.fs
@@ -89,6 +89,7 @@ type JEntity<'T> =
         | :? JEntity<Nodes.JsonArray>   as entity -> JEntity.map node entity    
         | :? JEntity<Nodes.JsonValue>   as entity -> JEntity.map node entity       
         | :? JEntity<Nodes.JsonObject>  as entity -> JEntity.map node entity    
+        | :? JEntity<Nodes.JsonNode>    as entity -> JEntity.map node entity    
         | :? JEntity<string>            as entity -> JEntity.map (JsonNode.ofGeneric<string>) entity
         | :? JEntity<int>               as entity -> JEntity.map (JsonNode.ofGeneric<int>) entity    
         | :? JEntity<float>             as entity -> JEntity.map (JsonNode.ofGeneric<float>) entity    

--- a/tests/JsonDSLTests.fsproj
+++ b/tests/JsonDSLTests.fsproj
@@ -16,6 +16,7 @@
     <None Include="Test.fsx" />
     <Compile Include="TestUtils.fs" />
     <Compile Include="Basetests.fs" />
+    <Compile Include="Operators.fs" />
     <Compile Include="ReferenceObjects.fs" />
     <Compile Include="TestObjects.fs" />
     <Compile Include="StringCreationTests.fs" />

--- a/tests/ObjectCreationTests.fs
+++ b/tests/ObjectCreationTests.fs
@@ -2,12 +2,39 @@
 
 
 open Expecto
+open JsonDSL
 open System.Text.Json
-open System.Text.Json.Nodes
+open TestUtils
+
 // These tests use the objects in TestObjects and compare them to the objects parsed from ReferenceObjects
 // a `DeepEquals` method is curtrently not available for System.text.Json, so we have to either wait or write such a function on our own.
 // i'll mark these tests as pending for now.
 // see also: https://stackoverflow.com/questions/60580743/what-is-equivalent-in-jtoken-deepequals-in-system-text-json
+
+[<Tests>]
+let ``yield JEntity tests`` =
+    testList "yield optional properties" [
+        testCase "jEntity_string_value" (fun _ ->
+            let result = 
+                object {
+                    property "myProperty" (-. (Option.Some "5"))                    
+                }
+               
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isValue (v.Value) "did not yield correct value"
+            Expect.equal (v.Value.AsValue() |> JsonValue.asString) "5" "yielded value was not correct"
+        )
+        testCase "jEntity_noneOptional_value" (fun _ ->
+            let result = 
+                object {
+                    property "myProperty" (-. Option.None)                    
+                }
+               
+            let v = result |> JsonObject.getProperties |> Seq.length
+            Expect.equal v 0 "Object should have no properties"
+        )
+    ]
 
 [<PTests>]
 let ``json string creation tests`` =

--- a/tests/Operators.fs
+++ b/tests/Operators.fs
@@ -1,0 +1,65 @@
+﻿module Operators
+
+
+open System.Text.Json
+open Expecto
+open JsonDSL
+open TestUtils
+// These tests use the objects in TestObjects and create an idented string via object.ToJsonString(), comparing them with the string from the ReferenceObjects module
+
+[<Tests>]
+let ``optional operator tests`` =
+    testList "optional operator" [
+        testCase "int_value" (fun _ ->
+            let result = -. 5
+            JEntity.isSome result "Int was not parsed correctly by optional operator"
+            JsonNode.isValue result.Value "Int was not parsed correctly by optional operator"
+            Expect.equal (JsonValue.tryAsInt (result.Value.AsValue())) (Option.Some 5) "Int was not parsed correctly by optional operator"
+        )
+        testCase "string_value" (fun _ ->
+            let result = -. "5"
+            JEntity.isSome result "String was not parsed correctly by optional operator"
+            JsonNode.isValue result.Value "String was not parsed correctly by optional operator"
+            Expect.equal (JsonValue.asString (result.Value.AsValue())) "5" "String was not parsed correctly by optional operator"
+        )
+        testCase "string_option" (fun _ ->
+            let result = -. (Option.Some "5")
+            JEntity.isSome result "String option was not parsed correctly by optional operator"
+            JsonNode.isValue result.Value "String option was not parsed correctly by optional operator"
+            Expect.equal (JsonValue.asString (result.Value.AsValue())) "5" "String option was not parsed correctly by optional operator"
+        )
+        testCase "option_none" (fun _ ->
+            let v : option<string> = Option.None
+            let result = -. v
+            JEntity.isNoneOptional result "String option was not parsed correctly by optional operator"
+        )
+    ]
+
+[<Tests>]
+let ``required operator tests`` =
+    testList "required operator" [
+        testCase "int_value" (fun _ ->
+            let result = +. 5
+            JEntity.isSome result "Int was not parsed correctly by required operator"
+            JsonNode.isValue result.Value "Int was not parsed correctly by required operator"
+            Expect.equal (JsonValue.tryAsInt (result.Value.AsValue())) (Option.Some 5) "Int was not parsed correctly by required operator"
+        )
+        testCase "string_value" (fun _ ->
+            let result = +. "5"
+            JEntity.isSome result "String was not parsed correctly by required operator"
+            JsonNode.isValue result.Value "String was not parsed correctly by required operator"
+            Expect.equal (JsonValue.asString (result.Value.AsValue())) "5" "String was not parsed correctly by required operator"
+        )
+        testCase "string_option" (fun _ ->
+            let result = +. (Option.Some "5")
+            JEntity.isSome result "String option was not parsed correctly by required operator"
+            JsonNode.isValue result.Value "String option was not parsed correctly by required operator"
+            Expect.equal (JsonValue.asString (result.Value.AsValue())) "5" "String option was not parsed correctly by required operator"
+        )
+        testCase "option_none" (fun _ ->
+            let v : option<string> = Option.None
+            let result = +. v
+            JEntity.isNoneRequired result "String option was not parsed correctly by required operator"
+        )
+    ]
+    

--- a/tests/TestUtils.fs
+++ b/tests/TestUtils.fs
@@ -1,10 +1,70 @@
 ﻿module TestUtils
 
+open System.Text.Json
 open System.Reflection
 open System.IO
+open JsonDSL
+open Expecto
 
 let getEmbeddedJsonString (filename:string) =
     let assembly = Assembly.GetExecutingAssembly()
     use str = assembly.GetManifestResourceStream($"JsonDSLTests.{filename}")
     use r = new StreamReader(str)
     r.ReadToEnd()
+
+module JEntity =
+    let inline isSome (x : JEntity<'T>) message = 
+        match x with
+        | Some _ -> ()
+        | NoneOptional _  ->
+            failtestf "%s. Expected Some _, was NoneOptional." message
+        | NoneRequired _  ->
+            failtestf "%s. Expected Some _, was NonRequired." message
+
+    let inline isNoneOptional (x : JEntity<'T>) message = 
+        match x with
+        | Some _ -> failtestf "%s. Expected Some _, was Some." message
+        | NoneOptional _  ->
+            ()          
+        | NoneRequired _  ->
+            failtestf "%s. Expected Some _, was NonRequired." message
+
+    let inline isNoneRequired (x : JEntity<'T>) message = 
+        match x with
+        | Some _ -> failtestf "%s. Expected Some _, was Some." message
+        | NoneOptional _  ->
+            failtestf "%s. Expected Some _, was NoneOptional." message
+        | NoneRequired _  ->
+            ()
+
+
+module JsonNode =
+
+    let inline isValue (x : Nodes.JsonNode) message = 
+        match x with
+        | Value _ -> ()
+        | Array _  ->
+            failtestf "%s. Expected Json Value _, was Json Array." message
+        | Object _  ->
+            failtestf "%s. Expected Json Value _, was Json Object." message
+        | _ -> failtestf "%s. Expected Json Value _, was Unknown Object." message  
+
+    let inline isObject (x : Nodes.JsonNode) message = 
+        match x with
+        | Value _ -> 
+            failtestf "%s. Expected Json Object _, was Json Value." message
+        | Array _  ->
+            failtestf "%s. Expected Json Object _, was Json Array." message
+        | Object _  ->
+            ()
+        | _ -> failtestf "%s. Expected Json Object _, was Unknown Object." message  
+
+    let inline isArray (x : Nodes.JsonNode) message = 
+        match x with
+        | Value _ -> 
+            failtestf "%s. Expected Json Array _, was Json Value." message
+        | Array _  ->
+            ()
+        | Object _  ->
+            failtestf "%s. Expected Json Array _, was Json Object." message
+        | _ -> failtestf "%s. Expected Json Array _, was Unknown Object." message   


### PR DESCRIPTION
Values created by the `-.` could not be properly yielded by the `property` expression of the `object` computation expression. Fixed the issue and added tests