### PR TITLE
CE improvements, some docs

### DIFF
--- a/src/JsonDSL/DSL.fs
+++ b/src/JsonDSL/DSL.fs
@@ -9,11 +9,11 @@ module DSL =
     let object = ObjectBuilder()
     let array = ArrayBuilder()
 
-    /// Optional operators for object and array expressions
-    let optionaL = OptionalSource()
+    /// Optional for array expressions
+    let optionalArray = OptionalSource()
 
-    /// Required operators for object and array expressions
-    let requireD = RequiredSource()
+    /// Required operators for array expressions
+    let requiredArray = RequiredSource()
 
     let inline parseExpression (def : exn -> JEntity<Nodes.JsonNode>) (s : Expr<'a>) : JEntity<Nodes.JsonNode> =
         try 

--- a/src/JsonDSL/DSL.fs
+++ b/src/JsonDSL/DSL.fs
@@ -49,6 +49,11 @@ module DSL =
         | :? Option<byte> as o ->               parseOption f o
         | :? Option<System.DateTime> as o ->    parseOption f o
 
+        | :? Option<Nodes.JsonArray> as o ->  parseOption f o
+        | :? Option<Nodes.JsonValue> as o ->  parseOption f o
+        | :? Option<Nodes.JsonObject> as o -> parseOption f o
+        | :? Option<Nodes.JsonNode> as o ->   parseOption f o
+
         | :? Result<string,exn> as r -> parseResult f r
         | :? Result<int,exn> as r -> parseResult f r
         | :? Result<float,exn> as r -> parseResult f r

--- a/src/JsonDSL/FSharpExtensions.fs
+++ b/src/JsonDSL/FSharpExtensions.fs
@@ -92,9 +92,10 @@ module FSharpExtensions =
         /// Returns the value as 'T if possible, else returns None
         let tryAs<'T> (v : Nodes.JsonValue) =
             let b,v = v.TryGetValue<'T>()
+            
             if b then Some v else None
 
-        let castAs<'T> (v : Nodes.JsonValue) = (tryAs<'T> v).Value
+        let castAs<'T> (v : Nodes.JsonValue) = v.Deserialize<'T>()
 
         /// Returns the value as string if possible, else returns None
         let tryAsString (v : Nodes.JsonValue) = tryAs<string> v
@@ -133,7 +134,7 @@ module FSharpExtensions =
         let tryAs<'T> (a : Nodes.JsonArray) = 
             try Some (a.Deserialize<'T []>()) with _ -> None
 
-        let castAs<'T> (a : Nodes.JsonArray) = (tryAs<'T> a).Value
+        let castAs<'T> (a : Nodes.JsonArray) = a.Deserialize<'T []>()
 
         /// Returns all the elements of the JsonArray
         let getElements (a : Nodes.JsonArray) =

--- a/src/JsonDSL/FSharpExtensions.fs
+++ b/src/JsonDSL/FSharpExtensions.fs
@@ -89,25 +89,36 @@ module FSharpExtensions =
         let isEmpty (v : Nodes.JsonValue) = 
             v.ToJsonString() = "\"\""
 
-        /// Returns the value as string
-        let asString (v : Nodes.JsonValue) =
-            let b,v = v.TryGetValue()
-            string v
+        /// Returns the value as 'T if possible, else returns None
+        let tryAs<'T> (v : Nodes.JsonValue) =
+            let b,v = v.TryGetValue<'T>()
+            if b then Some v else None
+
+        let castAs<'T> (v : Nodes.JsonValue) = (tryAs<'T> v).Value
 
         /// Returns the value as string if possible, else returns None
-        let tryAsString (v : Nodes.JsonValue) =
-            let b,v = v.TryGetValue()
-            try v |> string |> Some with | _ -> None
-
-        /// Returns the value as float if possible, else returns None
-        let tryAsFloat (v : Nodes.JsonValue) =
-            let b,v = v.TryGetValue()
-            try v |> float |> Some with | _ ->None
+        let tryAsString (v : Nodes.JsonValue) = tryAs<string> v
 
         /// Returns the value as int if possible, else returns None
-        let tryAsInt (v : Nodes.JsonValue) =
-            let b,v = v.TryGetValue()
-            try v |> int |> Some with | _ -> None
+        let tryAsInt (v : Nodes.JsonValue) = tryAs<int> v
+
+        /// Returns the value as float if possible, else returns None
+        let tryAsFloat (v : Nodes.JsonValue) = tryAs<float> v
+
+        /// Returns the value as DateTime if possible, else returns None
+        let tryAsDateTime (v : Nodes.JsonValue) = tryAs<System.DateTime> v
+
+        /// Returns the value as string
+        let asString (v : Nodes.JsonValue) = castAs<string> v
+
+        /// Returns the value as int
+        let asInt (v : Nodes.JsonValue) = castAs<int> v
+
+        /// Returns the value as float
+        let asFloat (v : Nodes.JsonValue) = castAs<float> v
+
+        /// Returns the value as DateTime
+        let asDateTime (v : Nodes.JsonValue) = castAs<System.DateTime> v
 
         let inline create (v : 'T) =
             Nodes.JsonValue.Create(v)
@@ -119,6 +130,11 @@ module FSharpExtensions =
         let isEmpty (a : Nodes.JsonArray) = 
             a.Count = 0
             
+        let tryAs<'T> (a : Nodes.JsonArray) = 
+            try Some (a.Deserialize<'T []>()) with _ -> None
+
+        let castAs<'T> (a : Nodes.JsonArray) = (tryAs<'T> a).Value
+
         /// Returns all the elements of the JsonArray
         let getElements (a : Nodes.JsonArray) =
             a

--- a/src/JsonDSL/ObjectBuilder.fs
+++ b/src/JsonDSL/ObjectBuilder.fs
@@ -60,11 +60,11 @@ type ObjectBuilder() =
         |> OptionalSource
 
     /// Select output
-    [<CustomOperation("required")>]
+    [<CustomOperation("requiredObject")>]
     member x.Required<'T> (fields : Properties) : RequiredSource<Properties> =
         RequiredSource(fields)
 
-    [<CustomOperation("optional")>]
+    [<CustomOperation("optionalObject")>]
     member x.Optional<'T> (fields : Properties) : OptionalSource<Properties> =
         OptionalSource(fields)
 

--- a/tests/ObjectCreationTests.fs
+++ b/tests/ObjectCreationTests.fs
@@ -99,6 +99,106 @@ let ``yield required JEntity tests`` =
         testCase "missing required value fails" (fun _ -> Expect.throws (fun _ -> object {property "myProperty" (+. Option.None)} |> ignore) "object creation with missing required property value did not fail")
     ]
 
+[<Tests>]
+let ``optionalObject`` = 
+    testList "optionalObject" [
+        testCase "optionalObject is ommitted when inner expression fails" (fun _ ->
+            let r = object {
+                property "willFail" (object {
+                    optionalObject
+                    property "" (+. Option.None)
+                })
+            } 
+            Expect.isTrue (JsonObject.isEmpty r) "object was not empty"
+            Expect.isFalse (r |> JsonObject.hasProperty "willFail") "expected property to be ommitted"
+        )
+        testCase "optionalObject is present when inner expression succeeds" (fun _ ->
+            let r = object {
+                property "willWork" (object {
+                    optionalObject
+                    property "hi" (-. (Option.Some 5.))
+                })
+            } 
+            Expect.isFalse (JsonObject.isEmpty r) "object was not empty"
+            Expect.isTrue (r |> JsonObject.hasProperty "willWork") "expected property to be present"
+        )
+    ]
+
+[<Tests>]
+let ``requiredObject`` = 
+    testList "requiredObject" [
+        testCase "requiredObject fails when inner expression fails" (fun _ ->
+            let r() = 
+                object {
+                    property "willFail" (object {
+                        requiredObject
+                        property "hi" (+. Option.None)
+                    }) 
+                } |> ignore
+            Expect.throws r "object creation with missing required property value did not fail"
+        )
+        testCase "requiredObject is present when inner expression succeeds" (fun _ ->
+            let r = object {
+                property "willWork" (object {
+                    requiredObject
+                    property "hi" (+. (Option.Some 5.))
+                })
+            } 
+            Expect.isFalse (JsonObject.isEmpty r) "object was not empty"
+            Expect.isTrue (r |> JsonObject.hasProperty "willWork") "expected property to be present"
+        )
+    ]
+
+[<Tests>]
+let ``optionalArray`` = 
+    testList "optionalArray" [
+        testCase "optionalArray is ommitted when inner expression fails" (fun _ ->
+            let r = object {
+                property "willFail" (array {
+                    yield optionalArray
+                    yield (+. Option.None)
+                })
+            } 
+            Expect.isTrue (JsonObject.isEmpty r) "object was not empty"
+            Expect.isFalse (r |> JsonObject.hasProperty "willFail") "expected property to be ommitted"
+        )
+        testCase "optionalArray is present when inner expression succeeds" (fun _ ->
+            let r = object {
+                property "willWork" (array {
+                    yield optionalArray
+                    yield (-. (Option.Some 5.))
+                })
+            } 
+            Expect.isFalse (JsonObject.isEmpty r) "object was not empty"
+            Expect.isTrue (r |> JsonObject.hasProperty "willWork") "expected property to be present"
+        )
+    ]
+
+[<Tests>]
+let ``requiredArray`` = 
+    testList "requiredArray" [
+        testCase "requiredArray fails when inner expression fails" (fun _ ->
+            let r() = 
+                object {
+                    property "willFail" (array {
+                        yield requiredArray
+                        yield (+. Option.None)
+                    }) 
+                } |> ignore
+            Expect.throws r "object creation with missing required property value did not fail"
+        )
+        testCase "requiredArray is present when inner expression succeeds" (fun _ ->
+            let r = object {
+                property "willWork" (array {
+                    yield requiredArray
+                    yield (+. (Option.Some 5.))
+                })
+            } 
+            Expect.isFalse (JsonObject.isEmpty r) "object was not empty"
+            Expect.isTrue (r |> JsonObject.hasProperty "willWork") "expected property to be present"
+        )
+    ]
+
 [<PTests>]
 let ``json string creation tests`` =
     testList "json object creation" [

--- a/tests/ObjectCreationTests.fs
+++ b/tests/ObjectCreationTests.fs
@@ -14,6 +14,15 @@ open TestUtils
 [<Tests>]
 let ``yield JEntity tests`` =
     testList "yield optional properties" [
+        testCase "jEntity_noneOptional_value" (fun _ ->
+            let result = 
+                object {
+                    property "myProperty" (-. Option.None)                    
+                }
+               
+            let v = result |> JsonObject.getProperties |> Seq.length
+            Expect.equal v 0 "Object should have no properties"
+        )
         testCase "jEntity_string_value" (fun _ ->
             let result = 
                 object {
@@ -25,14 +34,63 @@ let ``yield JEntity tests`` =
             JsonNode.isValue (v.Value) "did not yield correct value"
             Expect.equal (v.Value.AsValue() |> JsonValue.asString) "5" "yielded value was not correct"
         )
-        testCase "jEntity_noneOptional_value" (fun _ ->
+        testCase "jEntity_int_value" (fun _ ->
             let result = 
                 object {
-                    property "myProperty" (-. Option.None)                    
+                    property "myProperty" (-. (Option.Some 5))                    
                 }
                
-            let v = result |> JsonObject.getProperties |> Seq.length
-            Expect.equal v 0 "Object should have no properties"
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isValue (v.Value) "did not yield correct value"
+            Expect.equal (v.Value.AsValue() |> JsonValue.asInt) 5 "yielded value was not correct"
+        )        
+        testCase "jEntity_float_value" (fun _ ->
+            let result = 
+                object {
+                    property "myProperty" (-. (Option.Some 5.))                    
+                }
+               
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isValue (v.Value) "did not yield correct value"
+            Expect.equal (v.Value.AsValue() |> JsonValue.asFloat) 5. "yielded value was not correct"
+        )
+        testCase "jEntity_datetime_value" (fun _ ->
+            let time = System.DateTime.Parse("10/10/2010")
+            let result = 
+                object {
+                    property "myProperty" (-. (Option.Some time))                    
+                }
+               
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isValue (v.Value) "did not yield correct value"
+            Expect.equal (v.Value.AsValue() |> JsonValue.asDateTime) time "yielded value was not correct"
+        )
+        testCase "jEntity_JsonArray_value" (fun _ ->
+            let arr = [|1; 2|]
+            let result = 
+                object {
+                    property "myProperty" (-. (Option.Some (array {1; 2})))                    
+                }
+               
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isArray (v.Value) "did not yield correct value"
+            Expect.equal (v.Value.AsArray() |> JsonArray.castAs<int>) arr "yielded array was not correct"
+        )
+        testCase "jEntity_JsonObject_value" (fun _ ->
+
+            let result = 
+                object {
+                    property "myProperty" (-. (Option.Some (object {property "key" "value"})))                    
+                }
+               
+            let v = result |> JsonObject.tryGetProperty "myProperty"
+            Expect.isSome v "did not yield correct property"
+            JsonNode.isObject (v.Value) "did not yield correct value"
+            Expect.isTrue (JsonObject.hasProperty "key" (v.Value.AsObject())) "yielded object was not correct"
         )
     ]
 

--- a/tests/ObjectCreationTests.fs
+++ b/tests/ObjectCreationTests.fs
@@ -12,16 +12,15 @@ open TestUtils
 // see also: https://stackoverflow.com/questions/60580743/what-is-equivalent-in-jtoken-deepequals-in-system-text-json
 
 [<Tests>]
-let ``yield JEntity tests`` =
-    testList "yield optional properties" [
+let ``yield optional JEntity tests`` =
+    testList "yield optional properties via (-.)" [
         testCase "jEntity_noneOptional_value" (fun _ ->
             let result = 
                 object {
                     property "myProperty" (-. Option.None)                    
                 }
                
-            let v = result |> JsonObject.getProperties |> Seq.length
-            Expect.equal v 0 "Object should have no properties"
+            Expect.isTrue (JsonObject.isEmpty result) "Object should have no properties"
         )
         testCase "jEntity_string_value" (fun _ ->
             let result = 
@@ -92,6 +91,12 @@ let ``yield JEntity tests`` =
             JsonNode.isObject (v.Value) "did not yield correct value"
             Expect.isTrue (JsonObject.hasProperty "key" (v.Value.AsObject())) "yielded object was not correct"
         )
+    ]
+
+[<Tests>]
+let ``yield required JEntity tests`` =
+    testList "yield required properties via (+.)" [
+        testCase "missing required value fails" (fun _ -> Expect.throws (fun _ -> object {property "myProperty" (+. Option.None)} |> ignore) "object creation with missing required property value did not fail")
     ]
 
 [<PTests>]


### PR DESCRIPTION
this PR
- adds match cases for Option<JsonNode> (JsonArray, Object, Value, Node) to the `parseAny` function. the main reason is i want to be able to do this:
  ```fsharp
  let myOptionalObject = Some (object {property "key" "value"})
  object {
    property "optional" (-. myOptionalObject  )
  }
  ```

- changes `optional` -> `optionalObject` and `optionaL` -> `optionalArray` to make it more clear how to use them:
  ```fsharp
  object {
      property "willFail" (object {
        optionalObject
        property "" (+. Option.None)
  }) // will return {}

  object {
      property "willFail" (array {
          yield optionalArray
          yield (+. Option.None)
      }) // will return {}
  ```

- changes `required` -> `requiredObject` and `requireD` -> `requiredArray` to make it more clear how to use them:
  ```fsharp
  object {
      property "willFail" (object {
        requiredObject
        property "" (+. Option.None)
  }) // will fail

  object {
      property "willFail" (array {
          yield optionalArray
          yield (+. Option.None)
      }) // will fail
  ```

- adds some more FSharpExtensions for JsonNodes, including some refactoring of existing functions
- adds tests
- adds some readme documentation